### PR TITLE
fix(ui): expose remote_file in [c] edit sync panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-02-26
+
+### Fixed
+- `[c]` → "Modifica sync": aggiunto campo `remote_file` come campo modificabile interattivamente
+  - Consente di correggere il nome del file remoto (es. da `config.json.enc` a `isp.enc`) senza editare `contexts.json` a mano
+  - Il file precedente nel repo remoto non viene rimosso automaticamente (farlo manualmente con `git rm`)
+
 ## [1.3.0] - 2026-02-26
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sshmenuc"
-version = "1.3.0"
+version = "1.3.1"
 description = "Command line SSH menu and helper utility with cluster support (OO rewrite)."
 readme = "README.md"
 authors = ["Davide Isoardi <davide@isoardi.info>"]

--- a/sshmenuc/__init__.py
+++ b/sshmenuc/__init__.py
@@ -2,7 +2,7 @@ from .core import ConnectionManager, ConnectionNavigator, SSHLauncher
 from .ui import Colors, MenuDisplay
 from .utils import setup_logging, setup_argument_parser
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __all__ = [
     'ConnectionManager', 
     'ConnectionNavigator', 

--- a/sshmenuc/core/navigation.py
+++ b/sshmenuc/core/navigation.py
@@ -629,10 +629,13 @@ class ConnectionNavigator(BaseSSHMenuC):
         input("\nPress Enter to continue...")
 
     def _handle_edit_context_sync(self, name: str) -> None:
-        """Edit the sync configuration (remote_url, branch) of a context.
+        """Edit the sync configuration (remote_url, branch, remote_file) of a context.
 
         If the edited context is currently active, the SyncManager is
         reinitialized in-session so subsequent saves use the new config.
+
+        Changing remote_file only affects future pushes; the old file in the
+        remote repo must be removed manually if no longer needed.
 
         Args:
             name: Name of the context whose sync config should be updated.
@@ -640,14 +643,16 @@ class ConnectionNavigator(BaseSSHMenuC):
         current_cfg = self._context_manager.get_sync_cfg(name)
 
         puts(colored.cyan(f"\n--- Modifica sync: {name} ---"))
-        puts(colored.white(f"  remote_url: {current_cfg.get('remote_url', '(non configurato)')}"))
-        puts(colored.white(f"  branch:     {current_cfg.get('branch', 'main')}"))
+        puts(colored.white(f"  remote_url:  {current_cfg.get('remote_url', '(non configurato)')}"))
+        puts(colored.white(f"  branch:      {current_cfg.get('branch', 'main')}"))
+        puts(colored.white(f"  remote_file: {current_cfg.get('remote_file', '(non configurato)')}"))
         puts(colored.white("\nPremi Invio per mantenere il valore corrente.\n"))
 
         new_url = input("Nuovo remote URL: ").strip()
         new_branch = input("Nuovo branch: ").strip()
+        new_remote_file = input("Nuovo nome file remoto (es. isp.enc): ").strip()
 
-        if not new_url and not new_branch:
+        if not new_url and not new_branch and not new_remote_file:
             puts(colored.white("Nessuna modifica effettuata."))
             input("\nPress Enter to continue...")
             return
@@ -657,6 +662,9 @@ class ConnectionNavigator(BaseSSHMenuC):
             partial["remote_url"] = new_url
         if new_branch:
             partial["branch"] = new_branch
+        if new_remote_file:
+            partial["remote_file"] = new_remote_file
+            puts(colored.yellow(f"[SYNC] remote_file aggiornato → '{new_remote_file}'. Il prossimo push creerà questo file nel repo remoto."))
 
         self._context_manager.update_sync_config(name, partial)
         puts(colored.green(f"[CTX] Config sync di '{name}' aggiornata."))

--- a/tests/core/test_navigation.py
+++ b/tests/core/test_navigation.py
@@ -341,11 +341,11 @@ class TestContextManagement:
     # ------------------------------------------------------------------
 
     def test_edit_context_sync_no_changes_on_empty_input(self, temp_config_file):
-        """No update when user presses Enter for both fields."""
+        """No update when user presses Enter for all three fields."""
         nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
 
-        # Both new_url and new_branch empty → no update
-        with patch("builtins.input", side_effect=["", "", ""]):
+        # url, branch, remote_file all empty → no update; last "" is Enter to continue
+        with patch("builtins.input", side_effect=["", "", "", ""]):
             nav._handle_edit_context_sync("isp")
 
         ctx_mgr.update_sync_config.assert_not_called()
@@ -355,7 +355,8 @@ class TestContextManagement:
         nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
         nav._active_context = "home"  # "isp" is not active
 
-        with patch("builtins.input", side_effect=["git@github.com:new/repo.git", "", ""]):
+        # url, branch (empty), remote_file (empty), Enter to continue
+        with patch("builtins.input", side_effect=["git@github.com:new/repo.git", "", "", ""]):
             nav._handle_edit_context_sync("isp")
 
         ctx_mgr.update_sync_config.assert_called_once_with(
@@ -363,21 +364,32 @@ class TestContextManagement:
         )
 
     def test_edit_context_sync_updates_only_branch(self, temp_config_file):
-        """Only branch is updated when URL field is left empty."""
+        """Only branch is updated when URL and remote_file fields are left empty."""
         nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
         nav._active_context = "home"
 
-        with patch("builtins.input", side_effect=["", "develop", ""]):
+        with patch("builtins.input", side_effect=["", "develop", "", ""]):
             nav._handle_edit_context_sync("isp")
 
         ctx_mgr.update_sync_config.assert_called_once_with("isp", {"branch": "develop"})
+
+    def test_edit_context_sync_updates_remote_file(self, temp_config_file):
+        """remote_file is updated when provided; other fields left empty."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+        nav._active_context = "home"
+
+        with patch("builtins.input", side_effect=["", "", "isp.enc", ""]):
+            nav._handle_edit_context_sync("isp")
+
+        ctx_mgr.update_sync_config.assert_called_once_with("isp", {"remote_file": "isp.enc"})
 
     def test_edit_active_context_sync_reinitializes_sync_manager(self, temp_config_file):
         """Editing the active context reinitializes the SyncManager in-session."""
         nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
         old_sm = nav.sync_manager
 
-        with patch("builtins.input", side_effect=["git@github.com:new/repo.git", "", ""]), \
+        # url, branch (empty), remote_file (empty), Enter to continue
+        with patch("builtins.input", side_effect=["git@github.com:new/repo.git", "", "", ""]), \
              patch("sshmenuc.core.navigation.SyncManager") as MockSM:
             MockSM.return_value = MagicMock()
             nav._handle_edit_context_sync("home")  # "home" is the active context


### PR DESCRIPTION
## Summary

- `[c]` → "Modifica sync" ora mostra e permette di modificare anche `remote_file` (oltre a `remote_url` e `branch`)
- Utile per correggere il nome del file remoto legacy (es. `config.json.enc` → `isp.enc`)
- Il vecchio file nel repo remoto non viene rimosso automaticamente: va fatto manualmente con `git rm`

## Test plan

- [ ] 228 test passano
- [ ] `test_edit_context_sync_updates_remote_file` nuovo test case
- [ ] Test tutti i 4 campi aggiornati per rispecchiare il 4° input (remote_file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)