### PR TITLE
fix(ci): skip docs deploy on PR events

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,6 +48,7 @@ jobs:
           path: 'docs/_build/html'
 
   deploy:
+    if: github.event_name == 'push'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- Il job `deploy` nella Documentation workflow falliva su PR perché GitHub Pages non permette deploy da `refs/pull/N/merge`
- Fix: aggiunto `if: github.event_name == 'push'` al job `deploy`
- Su PR: solo il job `build` viene eseguito (verifica che la documentazione compili correttamente)
- Su push a main: sia `build` che `deploy` vengono eseguiti come prima

🤖 Generated with [Claude Code](https://claude.com/claude-code)