### PR TITLE
fix(sync): prevent false conflict in zero-plaintext mode on subsequent startups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-02-26
+
+### Fixed
+- **False conflict detection in zero-plaintext mode** (`startup_pull`): after the first
+  successful sync, the plaintext `config.json` is deleted. On subsequent startups,
+  `_hash_config_file()` returned `""` (file not found) which incorrectly triggered the
+  "both sides changed" conflict dialog on every run. Fixed by restoring `_config_data`
+  from the local `.enc` backup before the conflict check, so the local hash is computed
+  correctly from the actual local state.
+
 ## [1.3.1] - 2026-02-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sshmenuc"
-version = "1.3.1"
+version = "1.3.2"
 description = "Command line SSH menu and helper utility with cluster support (OO rewrite)."
 readme = "README.md"
 authors = ["Davide Isoardi <davide@isoardi.info>"]

--- a/sshmenuc/__init__.py
+++ b/sshmenuc/__init__.py
@@ -2,7 +2,7 @@ from .core import ConnectionManager, ConnectionNavigator, SSHLauncher
 from .ui import Colors, MenuDisplay
 from .utils import setup_logging, setup_argument_parser
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 __all__ = [
     'ConnectionManager', 
     'ConnectionNavigator', 

--- a/sshmenuc/sync/sync_manager.py
+++ b/sshmenuc/sync/sync_manager.py
@@ -124,6 +124,23 @@ class SyncManager:
             self._state = SyncState.SYNC_OFFLINE
             return self._state
 
+        # Zero-plaintext mode: the plaintext file may have been deleted by a
+        # previous successful startup (_wire_encrypted_io removes it once .enc
+        # is verified). Restore _config_data from the local .enc backup so that
+        # _hash_config_file() returns the correct local hash and avoids a false
+        # "both sides changed" conflict on every subsequent startup.
+        if (self._config_data is None
+                and not os.path.isfile(self._config_file)
+                and os.path.isfile(self._enc_path)):
+            try:
+                with open(self._enc_path, "rb") as _f:
+                    _local_enc = _f.read()
+                if _local_enc:
+                    self._config_data = decrypt_config(_local_enc, get_or_prompt())
+            except Exception as _e:
+                logging.debug("[SYNC] Cannot restore local backup for conflict check: %s", _e)
+                # _config_data stays None; local_hash will be "" → treated as first sync
+
         local_hash = self._hash_config_file()
         last_hash = self._sync_cfg.get("last_config_hash", "")
 

--- a/tests/sync/test_sync_manager.py
+++ b/tests/sync/test_sync_manager.py
@@ -548,6 +548,91 @@ class TestSyncMetaCallback:
 
         assert callback_calls == [], "Callback must NOT be called in single-file mode"
 
+    def test_no_false_conflict_zero_plaintext_same_remote(self, tmp_path):
+        """No conflict when plaintext is absent, local .enc matches remote and last hash.
+
+        This simulates the second startup in zero-plaintext mode after a successful
+        first sync: the plaintext file was deleted but the local .enc backup exists
+        with the same data as the remote. Conflict must NOT be triggered.
+        """
+        import hashlib
+        from sshmenuc.sync.crypto import encrypt_config
+
+        hosts_config = {"targets": [{"ISP": [{"host": "srv1.isp.net"}]}]}
+        local_hash = hashlib.sha256(json.dumps(hosts_config, indent=4).encode()).hexdigest()
+
+        # contexts.json has last_config_hash from the previous successful sync
+        override = {**SYNC_CFG, "last_config_hash": local_hash}
+        # Local .enc backup has the same data as remote
+        remote_enc = encrypt_config(hosts_config, PASSPHRASE)
+
+        # Config file does NOT exist (deleted by _wire_encrypted_io after first sync)
+        cfg_path = str(tmp_path / "config.json")
+        enc_path = cfg_path + ".enc"
+
+        # Write local .enc backup
+        with open(enc_path, "wb") as f:
+            f.write(encrypt_config(hosts_config, PASSPHRASE))
+
+        m = SyncManager(cfg_path, sync_cfg_override=override)
+        # config.json does not exist, but enc backup does
+
+        conflict_called = []
+
+        with patch("sshmenuc.sync.sync_manager.get_or_prompt", return_value=PASSPHRASE), \
+             patch("sshmenuc.sync.sync_manager.is_remote_reachable", return_value=True), \
+             patch("sshmenuc.sync.sync_manager.ensure_repo_initialized", return_value=True), \
+             patch("sshmenuc.sync.sync_manager.pull_remote",
+                   return_value=MagicMock(status=PullStatus.OK, remote_enc_bytes=remote_enc)), \
+             patch.object(m, "_resolve_conflict",
+                          side_effect=lambda *a: conflict_called.append(True) or "abort"):
+            state = m.startup_pull()
+
+        assert conflict_called == [], "No conflict expected: remote and local .enc are in sync"
+        assert state == SyncState.SYNC_OK
+        assert m.get_config_data() == hosts_config
+
+    def test_conflict_detected_zero_plaintext_both_sides_changed(self, tmp_path):
+        """Conflict correctly detected when both local .enc AND remote changed since last sync."""
+        import hashlib
+        from sshmenuc.sync.crypto import encrypt_config
+
+        # Three distinct versions: initial, local edit, remote edit
+        initial_config = {"targets": [{"ISP": [{"host": "orig.isp.net"}]}]}
+        local_config = {"targets": [{"ISP": [{"host": "local-edit.isp.net"}]}]}
+        remote_config = {"targets": [{"ISP": [{"host": "remote-edit.isp.net"}]}]}
+
+        # last_config_hash represents the INITIAL state (both sides diverged from it)
+        initial_hash = hashlib.sha256(json.dumps(initial_config, indent=4).encode()).hexdigest()
+        override = {**SYNC_CFG, "last_config_hash": initial_hash}
+
+        remote_enc = encrypt_config(remote_config, PASSPHRASE)
+
+        cfg_path = str(tmp_path / "config.json")
+        enc_path = cfg_path + ".enc"
+
+        # Local .enc has the locally-edited data (diverged from initial_hash)
+        with open(enc_path, "wb") as f:
+            f.write(encrypt_config(local_config, PASSPHRASE))
+
+        m = SyncManager(cfg_path, sync_cfg_override=override)
+        conflict_called = []
+
+        with patch("sshmenuc.sync.sync_manager.get_or_prompt", return_value=PASSPHRASE), \
+             patch("sshmenuc.sync.sync_manager.is_remote_reachable", return_value=True), \
+             patch("sshmenuc.sync.sync_manager.ensure_repo_initialized", return_value=True), \
+             patch("sshmenuc.sync.sync_manager.pull_remote",
+                   return_value=MagicMock(status=PullStatus.OK, remote_enc_bytes=remote_enc)), \
+             patch.object(m, "_resolve_conflict",
+                          side_effect=lambda loc, rem: conflict_called.append((loc, rem)) or "remote"):
+            m.startup_pull()
+
+        # Conflict must be detected: both local and remote changed from last known state
+        assert len(conflict_called) == 1, "Conflict dialog expected"
+        loc, rem = conflict_called[0]
+        assert loc == local_config, "Local data must come from the restored .enc backup"
+        assert rem == remote_config
+
     def test_no_false_conflict_when_last_hash_empty(self, tmp_path):
         """First launch with empty last_config_hash must NOT trigger a conflict dialog."""
         from sshmenuc.sync.crypto import encrypt_config


### PR DESCRIPTION
## Summary
- In zero-plaintext mode, after a first successful sync `_wire_encrypted_io()` deletes the plaintext `config.json`. On every subsequent startup `_hash_config_file()` was returning `""` (no plaintext, `_config_data` not yet populated), causing `startup_pull()` to always enter the conflict resolution dialog even when local and remote were perfectly in sync.
- Fix: before computing `local_hash` in the conflict check, if `_config_data` is `None` and the plaintext file is absent but a local `.enc` backup exists, restore `_config_data` from the backup. This gives `_hash_config_file()` the correct local hash and avoids the false conflict.
- Added 2 regression tests: *no conflict when local .enc matches remote*, and *correct conflict detection when both sides genuinely diverged*.

## Background (related to empty menu on Linux)
The false-conflict bug is also a contributing factor to the "empty menu after SYNC:OK" issue reported on a Linux machine (first run). Root cause for that issue: the remote encrypted file was likely pushed from an empty config during initial wizard setup, while macOS continues to work off its local `.enc` backup. **Fix for data**: on macOS press `[s]` → `[m]` (manual sync) → conflict dialog appears → choose **`[L]`** (use local) to push the correct config with hosts to the remote. Linux will then get the correct data on next startup.

## Test plan
- [ ] `poetry run pytest tests/sync/test_sync_manager.py -v` — all 33 tests pass
- [ ] `poetry run pytest tests/ -q` — 230/230 pass
- [ ] Second startup on a machine that previously ran in zero-plaintext mode should no longer show conflict dialog when remote and local are in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)