### PR TITLE
feat(contexts): reimport from plaintext + source delete - v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2026-02-26
+
+### Added
+- **`[c]` → contesto → `[i]` Reimport da file in chiaro**: permette di reimportare un config JSON
+  in chiaro nel contesto corrente senza uscire dall'app. Il file viene cifrato con la passphrase
+  della sessione, salvato nel backup `.enc` locale e opzionalmente pushato al remote.
+  Se il contesto è attivo, la configurazione in memoria viene aggiornata immediatamente.
+- **Eliminazione file sorgente dopo import**: dopo aver importato un file in chiaro (wizard
+  `--add-context` o reimport da UI), l'app chiede se eliminare il file originale (default: sì).
+- **Sub-menu per i contesti nel `[c]`**: selezionando un contesto ora si apre un sub-menu con
+  `[m]` (Modifica parametri sync) e `[i]` (Reimport da file), invece di procedere direttamente
+  alla modifica.
+
 ## [1.3.2] - 2026-02-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sshmenuc"
-version = "1.3.2"
+version = "1.3.3"
 description = "Command line SSH menu and helper utility with cluster support (OO rewrite)."
 readme = "README.md"
 authors = ["Davide Isoardi <davide@isoardi.info>"]

--- a/sshmenuc/__init__.py
+++ b/sshmenuc/__init__.py
@@ -2,7 +2,7 @@ from .core import ConnectionManager, ConnectionNavigator, SSHLauncher
 from .ui import Colors, MenuDisplay
 from .utils import setup_logging, setup_argument_parser
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 __all__ = [
     'ConnectionManager', 
     'ConnectionNavigator', 

--- a/sshmenuc/contexts/wizard.py
+++ b/sshmenuc/contexts/wizard.py
@@ -67,6 +67,13 @@ def add_context_wizard(name: str, default_config_path: str = "") -> bool:
     if not os.path.isfile(config_file) and default_config_path and os.path.isfile(default_config_path):
         shutil.copy2(default_config_path, config_file)
         print(f"  Config importato da {default_config_path}")
+        del_src = input(f"  Eliminare il file sorgente? [S/n]: ").strip().lower()
+        if del_src != "n":
+            try:
+                os.unlink(default_config_path)
+                print("  File sorgente eliminato.")
+            except OSError as e:
+                print(f"  Impossibile eliminare il file: {e}")
 
     # Offer immediate first push
     answer = input("\nEseguire subito la prima sincronizzazione (push)? [s/N]: ").strip().lower()

--- a/sshmenuc/core/navigation.py
+++ b/sshmenuc/core/navigation.py
@@ -581,14 +581,14 @@ class ConnectionNavigator(BaseSSHMenuC):
         input("\nPress Enter to continue...")
 
     def _handle_context_manage(self) -> None:
-        """Handle 'c' key - Add a new context or edit the sync config of an existing one."""
+        """Handle 'c' key - Add a new context or manage an existing one."""
         names = self._context_manager.list_contexts()
 
         puts(colored.cyan("\n=== Gestione Contesti ==="))
         puts(colored.white("  [1] Nuovo contesto"))
         for i, name in enumerate(names, 2):
             marker = " *" if name == self._active_context else ""
-            puts(colored.white(f"  [{i}] Modifica sync: {name}{marker}"))
+            puts(colored.white(f"  [{i}] {name}{marker}"))
         puts(colored.white("\n[Invio] Annulla"))
 
         raw = input("> ").strip()
@@ -605,7 +605,110 @@ class ConnectionNavigator(BaseSSHMenuC):
             return
 
         if 0 <= idx < len(names):
-            self._handle_edit_context_sync(names[idx])
+            self._handle_context_actions(names[idx])
+
+    def _handle_context_actions(self, name: str) -> None:
+        """Sub-menu for a selected context: edit sync params or reimport from plaintext."""
+        marker = " *" if name == self._active_context else ""
+        puts(colored.cyan(f"\n--- {name}{marker} ---"))
+        puts(colored.white("  [m] Modifica parametri sync"))
+        puts(colored.white("  [i] Reimport da file in chiaro"))
+        puts(colored.white("\n[Invio] Annulla"))
+
+        choice = input("> ").strip().lower()
+        if choice == "m":
+            self._handle_edit_context_sync(name)
+        elif choice == "i":
+            self._handle_reimport_context(name)
+
+    def _handle_reimport_context(self, name: str) -> None:
+        """Reimport config from a plaintext JSON file into the context's encrypted store.
+
+        Reads a JSON file, encrypts it with the cached passphrase, writes the
+        local .enc backup, updates contexts.json metadata, and optionally pushes
+        to the remote repo.  Offers to delete the source plaintext file (default: yes).
+        """
+        import hashlib as _hashlib
+        import json as _json
+        from datetime import datetime, timezone
+        from ..sync.crypto import encrypt_config
+        from ..sync.passphrase_cache import get_or_prompt
+        from ..sync.git_remote import ensure_repo_initialized, push_remote
+
+        puts(colored.cyan(f"\n--- Reimport config: {name} ---"))
+
+        src_path = input("Percorso file in chiaro (JSON): ").strip()
+        if not src_path:
+            return
+
+        src_path = os.path.expanduser(src_path)
+        if not os.path.isfile(src_path):
+            puts(colored.red(f"[ERR] File non trovato: {src_path}"))
+            input("\nPress Enter to continue...")
+            return
+
+        try:
+            with open(src_path, "r") as f:
+                config_data = _json.load(f)
+        except (ValueError, OSError) as e:
+            puts(colored.red(f"[ERR] Impossibile leggere il file: {e}"))
+            input("\nPress Enter to continue...")
+            return
+
+        try:
+            passphrase = get_or_prompt("Passphrase sync: ")
+            enc_bytes = encrypt_config(config_data, passphrase)
+        except Exception as e:
+            puts(colored.red(f"[ERR] Cifratura fallita: {e}"))
+            input("\nPress Enter to continue...")
+            return
+
+        # Save .enc locally
+        enc_path = self._context_manager.get_enc_file(name)
+        self._context_manager.ensure_context_dir(name)
+        with open(enc_path, "wb") as f:
+            f.write(enc_bytes)
+
+        # Compute hash consistent with _hash_config_file() (uses json.dumps indent=4)
+        content_hash = _hashlib.sha256(
+            _json.dumps(config_data, indent=4).encode()
+        ).hexdigest()
+        self._context_manager.update_context_meta(
+            name,
+            datetime.now(timezone.utc).isoformat(),
+            content_hash,
+        )
+
+        # If this is the active context, update in-memory state immediately
+        if name == self._active_context:
+            self.sync_manager._config_data = config_data
+            self.sync_manager._sync_cfg["last_config_hash"] = content_hash
+            self.set_config(config_data)
+            self.config_manager.set_config(config_data)
+            puts(colored.green(f"[CTX] Config '{name}' ricaricata in memoria."))
+        else:
+            puts(colored.green(f"[CTX] Backup cifrato aggiornato per '{name}'."))
+
+        # Offer to delete source file (default: yes)
+        del_src = input(f"\nEliminare il file sorgente? [S/n]: ").strip().lower()
+        if del_src != "n":
+            try:
+                os.unlink(src_path)
+                puts(colored.yellow("[CTX] File sorgente eliminato."))
+            except OSError as e:
+                puts(colored.yellow(f"[CTX] Non riesco a eliminare il file: {e}"))
+
+        # Offer push to remote
+        sync_cfg = self._context_manager.get_sync_cfg(name)
+        if sync_cfg.get("remote_url"):
+            push_now = input("\nEseguire subito un push verso il repo remoto? [S/n]: ").strip().lower()
+            if push_now != "n":
+                if ensure_repo_initialized(sync_cfg) and push_remote(sync_cfg, enc_bytes):
+                    puts(colored.green("[SYNC] Push completato."))
+                else:
+                    puts(colored.yellow("[SYNC] Push fallito. Backup locale cifrato comunque aggiornato."))
+
+        input("\nPress Enter to continue...")
 
     def _handle_new_context(self) -> None:
         """Wizard to create a new context from within the running app."""

--- a/tests/contexts/test_wizard.py
+++ b/tests/contexts/test_wizard.py
@@ -81,8 +81,8 @@ class TestAddContextWizard:
             args_config=legacy_config,
             contexts_path=contexts_path,
             cache_dir=cache_dir,
-            # remote_url, branch, remote_file, sync_repo_path, skip push
-            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n"],
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (n), skip push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n", "n"],
         )
 
         assert result is True
@@ -118,7 +118,8 @@ class TestAddContextWizard:
             args_config=legacy_config,
             contexts_path=contexts_path,
             cache_dir=cache_dir,
-            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n"],
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (n), skip push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n", "n"],
         )
 
         assert result is True
@@ -138,7 +139,8 @@ class TestAddContextWizard:
             args_config=legacy_config,
             contexts_path=contexts_path,
             cache_dir=cache_dir,
-            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n"],
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (n), skip push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n", "n"],
         )
 
         expected = os.path.join(cache_dir, "personal", "config.json")
@@ -175,7 +177,8 @@ class TestAddContextWizard:
             args_config=legacy_config,
             contexts_path=contexts_path,
             cache_dir=cache_dir,
-            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "s"],
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (n), do push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n", "s"],
         )
 
         mock_enc.assert_called_once()
@@ -192,8 +195,47 @@ class TestAddContextWizard:
             args_config=nonexistent_config,
             contexts_path=contexts_path,
             cache_dir=cache_dir,
+            # No delete prompt here: file doesn't exist, so copy step is skipped
             inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "s"],
         )
 
         mock_push.assert_not_called()
         mock_enc.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Source file deletion after import
+    # ------------------------------------------------------------------
+
+    def test_import_deletes_source_when_confirmed(self, tmp_path, legacy_config):
+        """Wizard deletes the source plaintext file when user confirms deletion."""
+        contexts_path = str(tmp_path / "contexts.json")
+        cache_dir = str(tmp_path / "contexts")
+
+        assert os.path.isfile(legacy_config)
+
+        self._run_wizard(
+            name="personal",
+            args_config=legacy_config,
+            contexts_path=contexts_path,
+            cache_dir=cache_dir,
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (S), skip push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "s", "n"],
+        )
+
+        assert not os.path.isfile(legacy_config), "Source file should be deleted when user confirms"
+
+    def test_import_keeps_source_when_declined(self, tmp_path, legacy_config):
+        """Wizard keeps the source plaintext file when user declines deletion."""
+        contexts_path = str(tmp_path / "contexts.json")
+        cache_dir = str(tmp_path / "contexts")
+
+        self._run_wizard(
+            name="personal",
+            args_config=legacy_config,
+            contexts_path=contexts_path,
+            cache_dir=cache_dir,
+            # remote_url, branch, remote_file, sync_repo_path, delete-source (n), skip push
+            inputs=["git@github.com:user/cfg.git", "main", "personal.enc", "", "n", "n"],
+        )
+
+        assert os.path.isfile(legacy_config), "Source file should be kept when user declines"

--- a/tests/core/test_navigation.py
+++ b/tests/core/test_navigation.py
@@ -270,15 +270,15 @@ class TestContextManagement:
 
         mock_new.assert_called_once()
 
-    def test_handle_context_manage_choice_edit_sync(self, temp_config_file):
-        """Choice '2' selects the first context and calls _handle_edit_context_sync."""
+    def test_handle_context_manage_choice_selects_context(self, temp_config_file):
+        """Choice '2' selects the first context and calls _handle_context_actions."""
         nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
 
         with patch("builtins.input", return_value="2"), \
-             patch.object(nav, "_handle_edit_context_sync") as mock_edit:
+             patch.object(nav, "_handle_context_actions") as mock_actions:
             nav._handle_context_manage()
 
-        mock_edit.assert_called_once_with("home")
+        mock_actions.assert_called_once_with("home")
 
     def test_handle_context_manage_invalid_input(self, temp_config_file):
         """Non-numeric input in _handle_context_manage is silently ignored."""
@@ -396,3 +396,141 @@ class TestContextManagement:
 
         assert nav.sync_manager is not old_sm
         MockSM.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # _handle_context_actions
+    # ------------------------------------------------------------------
+
+    def test_handle_context_actions_cancel(self, temp_config_file):
+        """Empty input in _handle_context_actions cancels without side effects."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        with patch("builtins.input", return_value=""):
+            nav._handle_context_actions("isp")
+
+        ctx_mgr.update_sync_config.assert_not_called()
+
+    def test_handle_context_actions_m_calls_edit_sync(self, temp_config_file):
+        """Choice 'm' in _handle_context_actions calls _handle_edit_context_sync."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        with patch("builtins.input", return_value="m"), \
+             patch.object(nav, "_handle_edit_context_sync") as mock_edit:
+            nav._handle_context_actions("isp")
+
+        mock_edit.assert_called_once_with("isp")
+
+    def test_handle_context_actions_i_calls_reimport(self, temp_config_file):
+        """Choice 'i' in _handle_context_actions calls _handle_reimport_context."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        with patch("builtins.input", return_value="i"), \
+             patch.object(nav, "_handle_reimport_context") as mock_reimport:
+            nav._handle_context_actions("isp")
+
+        mock_reimport.assert_called_once_with("isp")
+
+    # ------------------------------------------------------------------
+    # _handle_reimport_context
+    # ------------------------------------------------------------------
+
+    def test_reimport_context_file_not_found(self, temp_config_file):
+        """_handle_reimport_context shows error and returns when file is missing."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        with patch("builtins.input", side_effect=["/nonexistent/file.json", ""]):
+            nav._handle_reimport_context("isp")
+
+        ctx_mgr.update_context_meta.assert_not_called()
+
+    def test_reimport_context_cancel_on_empty_path(self, temp_config_file):
+        """Empty file path cancels reimport without any side effects."""
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        with patch("builtins.input", return_value=""):
+            nav._handle_reimport_context("isp")
+
+        ctx_mgr.update_context_meta.assert_not_called()
+
+    def test_reimport_context_updates_active_context_in_memory(self, tmp_path, temp_config_file):
+        """Reimporting the active context updates in-memory config immediately."""
+        import json
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        # Write a plaintext JSON source file
+        src = tmp_path / "import_me.json"
+        config_data = {"targets": [{"ISP": [{"friendly": "router", "host": "192.168.1.1"}]}]}
+        src.write_text(json.dumps(config_data))
+
+        ctx_mgr.get_enc_file.return_value = str(tmp_path / "home.enc")
+        ctx_mgr.get_sync_cfg.return_value = {}  # no remote_url → skip push prompt
+
+        with patch("builtins.input", side_effect=[str(src), "n", ""]), \
+             patch("sshmenuc.sync.passphrase_cache.get_or_prompt", return_value="secret"), \
+             patch("sshmenuc.sync.crypto.encrypt_config", return_value=b"ENC"):
+            nav._handle_reimport_context("home")  # "home" is active
+
+        assert nav.sync_manager._config_data == config_data
+        ctx_mgr.update_context_meta.assert_called_once()
+
+    def test_reimport_context_deletes_source_when_confirmed(self, tmp_path, temp_config_file):
+        """Source file is deleted after reimport when user confirms."""
+        import json
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        src = tmp_path / "plain.json"
+        src.write_text(json.dumps({"targets": []}))
+
+        ctx_mgr.get_enc_file.return_value = str(tmp_path / "home.enc")
+        ctx_mgr.get_sync_cfg.return_value = {}
+
+        with patch("builtins.input", side_effect=[str(src), "s", ""]), \
+             patch("sshmenuc.sync.passphrase_cache.get_or_prompt", return_value="secret"), \
+             patch("sshmenuc.sync.crypto.encrypt_config", return_value=b"ENC"):
+            nav._handle_reimport_context("home")
+
+        assert not src.exists(), "Source file should be deleted when user confirms"
+
+    def test_reimport_context_keeps_source_when_declined(self, tmp_path, temp_config_file):
+        """Source file is kept after reimport when user declines deletion."""
+        import json
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        src = tmp_path / "plain.json"
+        src.write_text(json.dumps({"targets": []}))
+
+        ctx_mgr.get_enc_file.return_value = str(tmp_path / "home.enc")
+        ctx_mgr.get_sync_cfg.return_value = {}
+
+        with patch("builtins.input", side_effect=[str(src), "n", ""]), \
+             patch("sshmenuc.sync.passphrase_cache.get_or_prompt", return_value="secret"), \
+             patch("sshmenuc.sync.crypto.encrypt_config", return_value=b"ENC"):
+            nav._handle_reimport_context("home")
+
+        assert src.exists(), "Source file should be kept when user declines"
+
+    def test_reimport_context_pushes_to_remote_when_confirmed(self, tmp_path, temp_config_file):
+        """push_remote is called when user confirms push after reimport."""
+        import json
+        nav, ctx_mgr = self._make_navigator_with_context_manager(temp_config_file)
+
+        src = tmp_path / "plain.json"
+        src.write_text(json.dumps({"targets": []}))
+
+        ctx_mgr.get_enc_file.return_value = str(tmp_path / "home.enc")
+        ctx_mgr.get_sync_cfg.return_value = {
+            "remote_url": "git@github.com:user/cfg.git",
+            "branch": "main",
+            "remote_file": "home.enc",
+            "sync_repo_path": str(tmp_path / "repo"),
+        }
+
+        with patch("builtins.input", side_effect=[str(src), "n", "s", ""]), \
+             patch("sshmenuc.sync.passphrase_cache.get_or_prompt", return_value="secret"), \
+             patch("sshmenuc.sync.crypto.encrypt_config", return_value=b"ENC"), \
+             patch("sshmenuc.sync.git_remote.ensure_repo_initialized", return_value=True) as mock_init, \
+             patch("sshmenuc.sync.git_remote.push_remote", return_value=True) as mock_push:
+            nav._handle_reimport_context("home")
+
+        mock_init.assert_called_once()
+        mock_push.assert_called_once()


### PR DESCRIPTION
## Summary

- Nuovo flusso `[c]` → seleziona context → `[i]` **Reimport da file in chiaro**: legge un JSON in chiaro, lo cifra con la passphrase di sessione, aggiorna il backup `.enc` locale e il `last_config_hash` in `contexts.json`. Se il contesto è attivo, aggiorna immediatamente il config in memoria. Offre push remoto opzionale dopo l'import.
- Sub-menu contesti nel `[c]`: selezionare un context ora mostra `[m]` (Modifica parametri sync) e `[i]` (Reimport), invece di andare direttamente alla modifica.
- Wizard `--add-context`: dopo il copy del file sorgente, chiede se eliminarlo (default: S).

## Test plan

- [ ] `poetry run pytest tests/ -v` — 241 test passati
- [ ] `[c]` → context → `[i]` → path file JSON valido → verifica config aggiornato in RAM
- [ ] `[c]` → context → `[i]` → path inesistente → messaggio di errore, nessuna modifica
- [ ] Wizard con legacy config: conferma eliminazione → file rimosso; `n` → file rimasto
- [ ] Push dopo reimport: verifica context visibile su Linux dopo aggiornamento

🤖 Generated with [Claude Code](https://claude.com/claude-code)