### PR TITLE
fix(sync): normalize old-format config when loading from encrypted path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Menu vuoto dopo sync con config in formato vecchio**: quando un file `.enc` era stato creato
+  prima dell'introduzione del formato `targets` (v1.2.0), la decifratura restituiva dati in formato
+  vecchio (`{"GroupName": [...]}`) che venivano memorizzati senza normalizzazione. `get_node()`
+  cercava la chiave `"targets"` non trovandola → menu sempre vuoto. Fix: aggiunta
+  `_normalize_config()` in `BaseSSHMenuC` chiamata in tutti i punti in cui dati cifrati vengono
+  caricati in memoria (`load_config()` encrypted path, `_run_startup_pull()`, `_switch_to_context()`,
+  `_handle_reimport_context()`).
+
 ## [1.3.3] - 2026-02-26
 
 ### Added

--- a/sshmenuc/core/base.py
+++ b/sshmenuc/core/base.py
@@ -28,6 +28,17 @@ class BaseSSHMenuC(ABC):
         if not logging.getLogger().handlers:
             logging.basicConfig(level=logging.INFO)
     
+    @staticmethod
+    def _normalize_config(data: dict) -> dict:
+        """Convert old-format config (no 'targets' key) to targets-array format.
+
+        Old format: {"GroupName": [...], ...}
+        New format: {"targets": [{"GroupName": [...]}, ...]}
+        """
+        if isinstance(data, dict) and "targets" not in data:
+            return {"targets": [{k: v} for k, v in data.items()]}
+        return data
+
     def load_config(self):
         """Load and normalize the configuration file.
 
@@ -38,7 +49,7 @@ class BaseSSHMenuC(ABC):
         if self._encrypted_load is not None:
             data = self._encrypted_load()
             if data is not None:
-                self.config_data = data
+                self.config_data = self._normalize_config(data)
                 self._validate_host_entries()
                 return
             # If encrypted load returns None (not ready yet), fall through to plaintext

--- a/sshmenuc/core/navigation.py
+++ b/sshmenuc/core/navigation.py
@@ -55,7 +55,9 @@ class ConnectionNavigator(BaseSSHMenuC):
         state = self.sync_manager.startup_pull()
         data = self.sync_manager.get_config_data()
         if data is not None:
-            # Zero-plaintext mode: config is in memory, set directly without file I/O
+            # Zero-plaintext mode: config is in memory, set directly without file I/O.
+            # Normalize old-format (no "targets" key) data that may come from legacy .enc files.
+            data = self._normalize_config(data)
             self.set_config(data)
             self.config_manager.set_config(data)
         elif state == SyncState.SYNC_OK:
@@ -527,6 +529,7 @@ class ConnectionNavigator(BaseSSHMenuC):
         self._wire_encrypted_io()
         data = self.sync_manager.get_config_data()
         if data is not None:
+            data = self._normalize_config(data)
             self.set_config(data)
             self.config_manager.set_config(data)
         else:
@@ -683,8 +686,8 @@ class ConnectionNavigator(BaseSSHMenuC):
         if name == self._active_context:
             self.sync_manager._config_data = config_data
             self.sync_manager._sync_cfg["last_config_hash"] = content_hash
-            self.set_config(config_data)
-            self.config_manager.set_config(config_data)
+            self.set_config(self._normalize_config(config_data))
+            self.config_manager.set_config(self._normalize_config(config_data))
             puts(colored.green(f"[CTX] Config '{name}' ricaricata in memoria."))
         else:
             puts(colored.green(f"[CTX] Backup cifrato aggiornato per '{name}'."))

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -78,3 +78,47 @@ class TestBaseSSHMenuC:
         
         base.config_data = "invalid"
         assert base.validate_config() is False
+
+    def test_normalize_config_old_format(self):
+        """Test _normalize_config converts old-format (no targets key) to new format."""
+        old_fmt = {
+            "Casa": [{"friendly": "router", "host": "192.168.1.1"}],
+            "DXC": [{"friendly": "server", "host": "10.0.0.1"}],
+        }
+        result = ConcreteBaseSSHMenuC._normalize_config(old_fmt)
+        assert "targets" in result
+        assert len(result["targets"]) == 2
+        # Keys preserved under targets
+        keys = {list(t.keys())[0] for t in result["targets"]}
+        assert keys == {"Casa", "DXC"}
+
+    def test_normalize_config_new_format_unchanged(self):
+        """Test _normalize_config leaves new-format (has targets key) untouched."""
+        new_fmt = {"targets": [{"Casa": [{"friendly": "router", "host": "192.168.1.1"}]}]}
+        result = ConcreteBaseSSHMenuC._normalize_config(new_fmt)
+        assert result == new_fmt
+
+    def test_normalize_config_empty_dict(self):
+        """Test _normalize_config with empty dict produces empty targets list."""
+        result = ConcreteBaseSSHMenuC._normalize_config({})
+        assert result == {"targets": []}
+
+    def test_load_config_encrypted_path_old_format(self):
+        """Test load_config normalizes old-format data returned by _encrypted_load hook."""
+        base = ConcreteBaseSSHMenuC()
+        old_fmt = {
+            "Casa": [{"friendly": "router", "host": "192.168.1.1"}],
+        }
+        base._encrypted_load = lambda: old_fmt
+        base.load_config()
+        assert "targets" in base.config_data
+        assert len(base.config_data["targets"]) == 1
+        assert list(base.config_data["targets"][0].keys())[0] == "Casa"
+
+    def test_load_config_encrypted_path_new_format(self):
+        """Test load_config leaves new-format data from _encrypted_load hook unchanged."""
+        base = ConcreteBaseSSHMenuC()
+        new_fmt = {"targets": [{"Casa": [{"friendly": "router", "host": "192.168.1.1"}]}]}
+        base._encrypted_load = lambda: new_fmt
+        base.load_config()
+        assert base.config_data == new_fmt

--- a/tests/core/test_navigation.py
+++ b/tests/core/test_navigation.py
@@ -534,3 +534,65 @@ class TestContextManagement:
 
         mock_init.assert_called_once()
         mock_push.assert_called_once()
+
+
+class TestOldFormatNormalization:
+    """Tests that old-format config (no 'targets' key) is normalized when loaded
+    via the encrypted path, so the menu is never empty after a sync.
+
+    Regression test for: config.json.enc created before multi-context mode
+    contained old-format data; after decryption set_config() stored it without
+    normalizing, causing get_node() to return an empty dict.
+    """
+
+    OLD_FORMAT = {
+        "Casa": [{"friendly": "router", "host": "192.168.1.1", "user": "admin"}],
+        "DXC": [{"friendly": "server", "host": "10.0.0.1", "user": "user"}],
+    }
+
+    def test_run_startup_pull_normalizes_old_format(self, temp_config_file):
+        """_run_startup_pull normalizes old-format data returned by SyncManager."""
+        from sshmenuc.sync import SyncState
+
+        mock_sm = MagicMock()
+        mock_sm.startup_pull.return_value = SyncState.SYNC_OK
+        mock_sm.get_config_data.return_value = dict(self.OLD_FORMAT)
+        mock_sm._sync_cfg = {}
+
+        with patch("sshmenuc.core.navigation.SyncManager", return_value=mock_sm):
+            nav = ConnectionNavigator(temp_config_file)
+
+        assert "targets" in nav.config_data
+        assert len(nav.config_data["targets"]) == 2
+        # get_node() must return non-empty dict
+        root = nav.get_node([])
+        assert isinstance(root, dict)
+        assert "Casa" in root and "DXC" in root
+
+    def test_switch_to_context_normalizes_old_format(self, temp_config_file):
+        """_switch_to_context normalizes old-format data from the new SyncManager."""
+        from sshmenuc.sync import SyncState
+
+        ctx_mgr = MagicMock()
+        ctx_mgr.list_contexts.return_value = ["home", "work"]
+        ctx_mgr.get_sync_cfg.return_value = {"auto_pull": True}
+        ctx_mgr.get_config_file.return_value = temp_config_file
+
+        nav = ConnectionNavigator(
+            temp_config_file,
+            context_manager=ctx_mgr,
+            active_context="home",
+        )
+
+        mock_sm = MagicMock()
+        mock_sm.startup_pull.return_value = SyncState.SYNC_OK
+        mock_sm.get_config_data.return_value = dict(self.OLD_FORMAT)
+        mock_sm._sync_cfg = {}
+
+        with patch("sshmenuc.core.navigation.SyncManager", return_value=mock_sm):
+            result = nav._switch_to_context("work")
+
+        assert result is True
+        assert "targets" in nav.config_data
+        root = nav.get_node([])
+        assert "Casa" in root and "DXC" in root


### PR DESCRIPTION
## Summary

- `casa.enc` (e altri `.enc` creati prima di v1.2.0) contengono dati in formato vecchio (`{"GroupName": [...]}`) senza la chiave `"targets"`
- Dopo la decifratura, `set_config()` memorizzava i dati senza normalizzarli
- `get_node()` cercava `config_data.get("targets", [])` → lista vuota → **menu sempre vuoto dopo il sync**
- Fix: aggiunta `_normalize_config()` in `BaseSSHMenuC`, applicata in tutti i punti in cui dati cifrati vengono caricati in memoria

## Files modificati

- `sshmenuc/core/base.py` — aggiunto `_normalize_config()` staticmethod + normalizzazione nel percorso `load_config()` encrypted
- `sshmenuc/core/navigation.py` — normalizzazione in `_run_startup_pull()`, `_switch_to_context()`, `_handle_reimport_context()`
- `tests/core/test_base.py` — 5 nuovi test per `_normalize_config` e `load_config` encrypted path
- `tests/core/test_navigation.py` — 2 nuovi test per regressione old-format in startup e switch contesto
- `CHANGELOG.md` — aggiornato

## Test plan

- [ ] 248 test passati localmente
- [ ] Verificare avvio con `casa.enc` (formato vecchio) → menu mostra i gruppi Casa/DXC/Eustema/Valuepartners
- [ ] Verificare che il primo save migra il formato a `targets` nel `.enc` aggiornato

🤖 Generated with [Claude Code](https://claude.com/claude-code)